### PR TITLE
Fix ReadCString looping infinitely

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,9 +177,10 @@ trait ReadCString {
 
 impl ReadCString for Cursor<Vec<u8>> {
     fn read_cstring(&mut self) -> Result<String> {
+        let end = self.get_ref().len() as u64;
         let mut buf = [0; 1];
         let mut str_vec = Vec::with_capacity(256);
-        loop {
+        while self.position() < end {
             self.read(&mut buf)?;
             if buf[0] == 0 { break; } else { str_vec.push(buf[0]); }
         }


### PR DESCRIPTION
ReadCString previously looped infinitely if the last byte of the data was not `0` as the cursor kept at the same position and therefore repeatedly added the same byte into `str_vec`.