### PR TITLE
Dont run test with async feature

### DIFF
--- a/tests/info_test.rs
+++ b/tests/info_test.rs
@@ -1,5 +1,4 @@
-extern crate a2s;
-
+#[cfg(not(feature = "async"))]
 #[test]
 fn test_info() {
     let client = a2s::A2SClient::new().unwrap();


### PR DESCRIPTION
Running `cargo test --all-features` results in the `test_info` test failing since it's not setup to work with the async version of the client. This simply feature gates the test and removes the unneeded `extern crate ...` declaration since this crate is for the 2018 edition which makes it unnecessary.