### PR TITLE
Add support for GoldSource servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@
 
 An implementation of [Source A2S Queries](https://developer.valvesoftware.com/wiki/Server_queries)
 
-**Note: Only supports Source engine and above, Goldsource is not supported**
+**Note: Only supports Source and Steam GoldSource engine, WON GoldSource is not supported!**

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,8 @@ const MULTI_PACKET: i32 = -2;
 const OFS_HEADER: usize = 0;
 const OFS_SP_PAYLOAD: usize = 4;
 const OFS_MP_ID: usize = 4;
+
+// Offsets for Source
 const OFS_MP_SS_TOTAL: usize = 8;
 const OFS_MP_SS_NUMBER: usize = 9;
 const OFS_MP_SS_SIZE: usize = 10;
@@ -35,12 +37,16 @@ const OFS_MP_SS_BZ2_CRC: usize = 16;
 const OFS_MP_SS_PAYLOAD: usize = OFS_MP_SS_BZ2_SIZE;
 const OFS_MP_SS_PAYLOAD_BZ2: usize = OFS_MP_SS_BZ2_CRC + 4;
 
+// Offsets for GoldSource
+const OFS_MP_GS_PACKETNUMBER: usize = 8;
+const OFS_MP_GS_PAYLOAD: usize = 9;
+
 macro_rules! read_buffer_offset {
     ($buf:expr, $offset:expr, i8) => {
-        $buf[$offset].into()
+        $buf[$offset] as i8
     };
     ($buf:expr, $offset:expr, u8) => {
-        $buf[$offset].into()
+        $buf[$offset] as u8
     };
     ($buf:expr, $offset:expr, i16) => {
         i16::from_le_bytes([$buf[$offset], $buf[$offset + 1]])
@@ -304,14 +310,31 @@ impl A2SClient {
         if header == SINGLE_PACKET {
             Ok(data[OFS_SP_PAYLOAD..].to_vec())
         } else if header == MULTI_PACKET {
-            // ID - long (4 bytes)
-            // Total - byte (1 byte)
-            // Number - byte (1 byte)
-            // Size - short (2 bytes)
-
             let id = read_buffer_offset!(&data, OFS_MP_ID, i32);
-            let total_packets: usize = data[OFS_MP_SS_TOTAL].into();
-            let switching_size: usize = read_buffer_offset!(&data, OFS_MP_SS_SIZE, u16).into();
+
+            // Try to interpret the package as GoldSource
+            // Note: this won't work if the packets arrive out of order
+            let (total_packets, number, switching_size, ofs_payload) = if read_buffer_offset!(&data, OFS_MP_GS_PAYLOAD, i32) == SINGLE_PACKET {
+                // ID - long (4 bytes)
+                // Packet number - byte (1 byte):
+                //      high nibble - number of the current packet
+                //      low nibble  - total number of packets
+                let total_packets: usize = (read_buffer_offset!(&data, OFS_MP_GS_PACKETNUMBER, u8) & 0x0F).into();
+                let number: u8 = (read_buffer_offset!(&data, OFS_MP_GS_PACKETNUMBER, u8) >> 4).into();
+                let switching_size: usize = self.max_size;
+                (total_packets, number, switching_size, OFS_MP_GS_PAYLOAD)
+            }
+            // Rather seems like a Source packet
+            else {
+                // ID - long (4 bytes)
+                // Total - byte (1 byte)
+                // Number - byte (1 byte)
+                // Size - short (2 bytes)
+                let total_packets: usize = read_buffer_offset!(&data, OFS_MP_SS_TOTAL, u8).into();
+                let number: u8 = read_buffer_offset!(&data, OFS_MP_SS_NUMBER, u8).into();
+                let switching_size: usize = read_buffer_offset!(&data, OFS_MP_SS_SIZE, u16).into();
+                (total_packets, number, switching_size, OFS_MP_SS_PAYLOAD)
+            };
 
             // Sanity check
             if (switching_size > self.max_size) || (total_packets > 32) {
@@ -321,10 +344,10 @@ impl A2SClient {
             let mut packets: Vec<PacketFragment> = Vec::with_capacity(0);
             packets.try_reserve(total_packets)?;
             packets.push(PacketFragment {
-                number: data[OFS_MP_SS_NUMBER],
+                number,
                 // The first packet seems to include a single packet header (0xFFFFFFFF) for some
                 // reason, so we'd rather skip that (hence +4)
-                payload: Vec::from(&data[OFS_MP_SS_PAYLOAD + 4..]),
+                payload: Vec::from(&data[ofs_payload + 4..]),
             });
 
             loop {
@@ -348,8 +371,8 @@ impl A2SClient {
                 if id as u32 & 0x80000000 == 0 {
                     // Uncompressed packet
                     packets.push(PacketFragment {
-                        number: data[OFS_MP_SS_NUMBER],
-                        payload: Vec::from(&data[OFS_MP_SS_PAYLOAD..]),
+                        number,
+                        payload: Vec::from(&data[ofs_payload..]),
                     });
                 } else {
                     // BZip2 compressed packet

--- a/tests/async_test.rs
+++ b/tests/async_test.rs
@@ -52,3 +52,15 @@ async fn test_async_multipleservers() {
         fut = remaining;
     }
 }
+
+#[cfg(feature = "async")]
+#[tokio::test]
+async fn test_async_goldsource() {
+    let address = "45.83.244.193:27015";
+    let client = A2SClient::new().await.unwrap();
+    let info = client.info(&address);
+    let rules = client.rules(&address);
+    let players = client.players(&address);
+    let (info, rules, players) = try_join!(info, rules, players).unwrap();
+    println!("{:?}\n{:?}\n{:?}", info, rules, players);
+}

--- a/tests/async_test.rs
+++ b/tests/async_test.rs
@@ -56,11 +56,25 @@ async fn test_async_multipleservers() {
 #[cfg(feature = "async")]
 #[tokio::test]
 async fn test_async_goldsource() {
+    // Only servers providing multipacket responses are relevant for GoldSource tests
     let address = "45.83.244.193:27015";
     let client = A2SClient::new().await.unwrap();
     let info = client.info(&address);
     let rules = client.rules(&address);
     let players = client.players(&address);
     let (info, rules, players) = try_join!(info, rules, players).unwrap();
-    println!("{:?}\n{:?}\n{:?}", info, rules, players);
+    println!("Addr: {}\n{:?}\n{:?}\n{:?}", address, info, rules, players);
+}
+
+#[cfg(feature = "async")]
+#[tokio::test]
+async fn test_async_goldsource2() {
+    // Only servers providing multipacket responses are relevant for GoldSource tests
+    let address = "145.239.108.67:27025";
+    let client = A2SClient::new().await.unwrap();
+    let info = client.info(&address);
+    let rules = client.rules(&address);
+    let players = client.players(&address);
+    let (info, rules, players) = try_join!(info, rules, players).unwrap();
+    println!("Addr: {}\n{:?}\n{:?}\n{:?}", address, info, rules, players);
 }

--- a/tests/rules_test.rs
+++ b/tests/rules_test.rs
@@ -27,3 +27,14 @@ fn test_rules_multipacket2() {
 
     println!("{:?}", result);
 }
+
+#[cfg(not(feature = "async"))]
+#[test]
+fn test_rules_goldsource() {
+    let client = a2s::A2SClient::new().unwrap();
+
+    // Only servers providing multipacket responses are relevant for GoldSource tests
+    let result = client.rules("45.83.244.193:27015").unwrap();
+
+    println!("{:?}", result);
+}


### PR DESCRIPTION
The structure of Source and GoldSource responses only differ when they are multi-packet.
This addition aims to detect GoldSource responses and parse them properly.

It only works if the first packet arrives in order. I'm hugely dissatisfied by this but considering it's a rare occurrence and fixing it would take a massive overhaul, I have no capacity for that right now.