### PR TITLE
Handle when a server responds with nothing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,6 +160,11 @@ impl A2SClient {
         let read = future_timeout!(self.timeout, socket.recv(&mut data))?;
         data.truncate(read);
 
+        // Handle when a server responds with nothing
+        if data.len() == 0 {
+            return Err(Error::InvalidResponse);
+        }
+
         let header = read_buffer_offset!(&data, OFS_HEADER, i32);
 
         if header == SINGLE_PACKET {


### PR DESCRIPTION
If a query returns absolutely nothing, it can cause a panic in `read_buffer_offset!`:

```
thread 'tokio-runtime-worker' panicked at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\a2s-0.5.2\src\lib.rs:163:22:
index out of bounds: the len is 0 but the index is 0
stack backtrace:
   0: std::panicking::begin_panic_handler
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library\std\src\panicking.rs:697
   1: core::panicking::panic_fmt
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library\core\src\panicking.rs:75
   2: core::panicking::panic_bounds_check
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library\core\src\panicking.rs:281
   3: core::slice::index::impl$2::index<u8>
             at C:\Users\Winter\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\core\src\slice\index.rs:274
   4: alloc::vec::impl$13::index<u8,usize,alloc::alloc::Global>
             at C:\Users\Winter\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\alloc\src\vec\mod.rs:3376
   5: a2s::impl$0::send::async_fn$0<ref$<core::net::socket_addr::SocketAddrV4> >
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\a2s-0.5.2\src\lib.rs:53
   6: a2s::impl$0::do_challenge_request::async_fn$0<core::net::socket_addr::SocketAddrV4>
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\a2s-0.5.2\src\lib.rs:276
   7: a2s::rules::impl$1::rules::async_fn$0<core::net::socket_addr::SocketAddrV4>
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\a2s-0.5.2\src\rules.rs:77
   8: gmodhealth::add_to_a2s_rules_queue::async_block$0
             at .\src\main.rs:144
   9: tokio::runtime::task::core::impl$6::poll::closure$0<enum2$<gmodhealth::add_to_a2s_rules_queue::async_block_env$0>,alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle,alloc::alloc::Global> >
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\runtime\task\core.rs:365
  10: tokio::loom::std::unsafe_cell::UnsafeCell<enum2$<tokio::runtime::task::core::Stage<enum2$<gmodhealth::add_to_a2s_rules_queue::async_block_env$0> > > >::with_mut
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\loom\std\unsafe_cell.rs:16
  11: tokio::runtime::task::core::Core<enum2$<gmodhealth::add_to_a2s_rules_queue::async_block_env$0>,alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle,alloc::alloc::Global> >::poll<enum2$<gmodhealth::add_to_a2s_rules_queue::async_block_env
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\runtime\task\core.rs:354
  12: tokio::runtime::task::harness::poll_future::closure$0<enum2$<gmodhealth::add_to_a2s_rules_queue::async_block_env$0>,alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle,alloc::alloc::Global> >
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\runtime\task\harness.rs:535
  13: core::panic::unwind_safe::impl$25::call_once<enum2$<core::task::poll::Poll<tuple$<core::net::socket_addr::SocketAddrV4,enum2$<core::result::Result<alloc::vec::Vec<a2s::rules::Rule,alloc::alloc::Global>,enum2$<a2s::errors::Error> > > > > >,tokio::runtime::t
             at C:\Users\Winter\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\core\src\panic\unwind_safe.rs:272
  14: std::panicking::try::do_call<core::panic::unwind_safe::AssertUnwindSafe<tokio::runtime::task::harness::poll_future::closure_env$0<enum2$<gmodhealth::add_to_a2s_rules_queue::async_block_env$0>,alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle
             at C:\Users\Winter\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\std\src\panicking.rs:589
  15: std::panic::catch_unwind<core::panic::unwind_safe::AssertUnwindSafe<tokio::runtime::task::harness::poll_future::closure_env$0<enum2$<gmodhealth::add_to_a2s_rules_queue::async_block_env$0>,alloc::sync::Arc<tokio::runtime::scheduler::current_thread::Handle,a
  16: std::panicking::try
             at C:\Users\Winter\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\std\src\panicking.rs:552
  17: std::panic::catch_unwind<core::panic::unwind_safe::AssertUnwindSafe<tokio::runtime::task::harness::poll_future::closure_env$0<enum2$<gmodhealth::add_to_a2s_rules_queue::async_block_env$0>,alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Ha
             at C:\Users\Winter\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\std\src\panic.rs:359
  18: tokio::runtime::task::harness::poll_future<enum2$<gmodhealth::add_to_a2s_rules_queue::async_block_env$0>,alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle,alloc::alloc::Global> >
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\runtime\task\harness.rs:523
  19: tokio::runtime::task::harness::Harness<enum2$<gmodhealth::add_to_a2s_rules_queue::async_block_env$0>,alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle,alloc::alloc::Global> >::poll_inner<enum2$<gmodhealth::add_to_a2s_rules_queue::asy
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\runtime\task\harness.rs:210
  20: tokio::runtime::task::harness::Harness<enum2$<gmodhealth::add_to_a2s_rules_queue::async_block_env$0>,alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle,alloc::alloc::Global> >::poll<enum2$<gmodhealth::add_to_a2s_rules_queue::async_blo
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\runtime\task\harness.rs:155
  21: tokio::runtime::task::raw::poll<enum2$<gmodhealth::add_to_a2s_rules_queue::async_block_env$0>,alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle,alloc::alloc::Global> >
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\runtime\task\raw.rs:325
  22: tokio::runtime::task::raw::RawTask::poll
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\runtime\task\raw.rs:255
  23: tokio::runtime::task::LocalNotified<alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle,alloc::alloc::Global> >::run<alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle,alloc::alloc::Global> >
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\runtime\task\mod.rs:509
  24: tokio::runtime::scheduler::multi_thread::worker::impl$1::run_task::closure$0
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\runtime\scheduler\multi_thread\worker.rs:600
  25: tokio::task::coop::with_budget
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\task\coop\mod.rs:167
  26: tokio::task::coop::budget
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\task\coop\mod.rs:133
  27: tokio::runtime::scheduler::multi_thread::worker::Context::run_task
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\runtime\scheduler\multi_thread\worker.rs:591
  28: tokio::runtime::scheduler::multi_thread::worker::Context::run
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\runtime\scheduler\multi_thread\worker.rs:539
  29: tokio::runtime::scheduler::multi_thread::worker::run::closure$0::closure$0
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\runtime\scheduler\multi_thread\worker.rs:504
  30: tokio::runtime::context::scoped::Scoped<enum2$<tokio::runtime::scheduler::Context> >::set<enum2$<tokio::runtime::scheduler::Context>,tokio::runtime::scheduler::multi_thread::worker::run::closure$0::closure_env$0,tuple$<> >
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\runtime\context\scoped.rs:40
  31: tokio::runtime::context::set_scheduler::closure$0<tuple$<>,tokio::runtime::scheduler::multi_thread::worker::run::closure$0::closure_env$0>
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\runtime\context.rs:176
  32: std::thread::local::LocalKey<tokio::runtime::context::Context>::try_with<tokio::runtime::context::Context,tokio::runtime::context::set_scheduler::closure_env$0<tuple$<>,tokio::runtime::scheduler::multi_thread::worker::run::closure$0::closure_env$0>,tuple$<
             at C:\Users\Winter\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\std\src\thread\local.rs:315
  33: std::thread::local::LocalKey<tokio::runtime::context::Context>::with<tokio::runtime::context::Context,tokio::runtime::context::set_scheduler::closure_env$0<tuple$<>,tokio::runtime::scheduler::multi_thread::worker::run::closure$0::closure_env$0>,tuple$<> >
             at C:\Users\Winter\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\std\src\thread\local.rs:279
  34: tokio::runtime::context::set_scheduler<tuple$<>,tokio::runtime::scheduler::multi_thread::worker::run::closure$0::closure_env$0>
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\runtime\context.rs:176
  35: tokio::runtime::scheduler::multi_thread::worker::run::closure$0
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\runtime\scheduler\multi_thread\worker.rs:499
  36: tokio::runtime::context::runtime::enter_runtime<tokio::runtime::scheduler::multi_thread::worker::run::closure_env$0,tuple$<> >
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\runtime\context\runtime.rs:65
  37: tokio::runtime::scheduler::multi_thread::worker::run
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\runtime\scheduler\multi_thread\worker.rs:491
  38: tokio::runtime::scheduler::multi_thread::worker::impl$0::launch::closure$0
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\runtime\scheduler\multi_thread\worker.rs:457
  39: tokio::runtime::blocking::task::impl$2::poll<tokio::runtime::scheduler::multi_thread::worker::impl$0::launch::closure_env$0,tuple$<> >
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\runtime\blocking\task.rs:42
  40: tokio::runtime::task::core::impl$6::poll::closure$0<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::impl$0::launch::closure_env$0>,tokio::runtime::blocking::schedule::BlockingSchedule>
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\runtime\task\core.rs:365
  41: tokio::loom::std::unsafe_cell::UnsafeCell<enum2$<tokio::runtime::task::core::Stage<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::impl$0::launch::closure_env$0> > > >::with_mut
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\loom\std\unsafe_cell.rs:16
  42: tokio::runtime::task::core::Core<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::impl$0::launch::closure_env$0>,tokio::runtime::blocking::schedule::BlockingSchedule>::poll<tokio::runtime::blocking::task::Blocki
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\runtime\task\core.rs:354
  43: tokio::runtime::task::harness::poll_future::closure$0<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::impl$0::launch::closure_env$0>,tokio::runtime::blocking::schedule::BlockingSchedule>
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\runtime\task\harness.rs:535
  44: core::panic::unwind_safe::impl$25::call_once<enum2$<core::task::poll::Poll<tuple$<> > >,tokio::runtime::task::harness::poll_future::closure_env$0<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::impl$0::launch::
             at C:\Users\Winter\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\core\src\panic\unwind_safe.rs:272
  45: std::panicking::try::do_call<core::panic::unwind_safe::AssertUnwindSafe<tokio::runtime::task::harness::poll_future::closure_env$0<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::impl$0::launch::closure_env$0>,t
             at C:\Users\Winter\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\std\src\panicking.rs:589
  46: tokio::runtime::metrics::worker::WorkerMetrics::from_config
  47: std::panicking::try
             at C:\Users\Winter\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\std\src\panicking.rs:552
  48: std::panic::catch_unwind<core::panic::unwind_safe::AssertUnwindSafe<tokio::runtime::task::harness::poll_future::closure_env$0<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::impl$0::launch::closure_env$0>,tokio
             at C:\Users\Winter\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\std\src\panic.rs:359
  49: tokio::runtime::task::harness::poll_future<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::impl$0::launch::closure_env$0>,tokio::runtime::blocking::schedule::BlockingSchedule>
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\runtime\task\harness.rs:523
  50: tokio::runtime::task::harness::Harness<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::impl$0::launch::closure_env$0>,tokio::runtime::blocking::schedule::BlockingSchedule>::poll_inner<tokio::runtime::blocking::
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\runtime\task\harness.rs:210
  51: tokio::runtime::task::harness::Harness<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::impl$0::launch::closure_env$0>,tokio::runtime::blocking::schedule::BlockingSchedule>::poll<tokio::runtime::blocking::task::
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\runtime\task\harness.rs:155
  52: tokio::runtime::task::raw::poll<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::impl$0::launch::closure_env$0>,tokio::runtime::blocking::schedule::BlockingSchedule>
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\runtime\task\raw.rs:325
  53: tokio::runtime::task::raw::RawTask::poll
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\runtime\task\raw.rs:255
  54: tokio::runtime::task::UnownedTask<tokio::runtime::blocking::schedule::BlockingSchedule>::run<tokio::runtime::blocking::schedule::BlockingSchedule>
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\runtime\task\mod.rs:546
  55: tokio::runtime::blocking::pool::Task::run
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\runtime\blocking\pool.rs:161
  56: tokio::runtime::blocking::pool::Inner::run
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\runtime\blocking\pool.rs:516
  57: tokio::runtime::blocking::pool::impl$6::spawn_thread::closure$0
             at C:\Users\Winter\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\tokio-1.47.1\src\runtime\blocking\pool.rs:474
  58: core::hint::black_box
             at C:\Users\Winter\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\core\src\hint.rs:482
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
Error: JoinError::Panic(Id(5947), "index out of bounds: the len is 0 but the index is 0", ...)
```