### PR TITLE
Handle when the A2S header is truncated (less than a long/4 bytes)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,8 +174,8 @@ impl A2SClient {
         let read = future_timeout!(self.timeout, self.socket.recv(&mut data))?;
         data.truncate(read);
 
-        // Handle when a server responds with nothing
-        if data.len() == 0 {
+        // Header is a long (4 bytes)
+        if data.len() < 4 {
             return Err(Error::InvalidResponse);
         }
 


### PR DESCRIPTION
This builds on #21 by enforcing the minimum amount of data necessary to at least read the header.

```
thread 'tokio-runtime-worker' panicked at /home/ubuntu/.cargo/git/checkouts/a2s-rs-124001aa0c512075/2977913/src/lib.rs:168:22:
index out of bounds: the len is 2 but the index is 2
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Error: JoinError::Panic(Id(10714), "index out of bounds: the len is 2 but the index is 2", ...)
```

This could/should probably be expanded with more minimum `data.len()` checks before each `read_buffer_offset!`, but, at the very least I, will cross that bridge if/when it's a problem.